### PR TITLE
Tests and additional docker args

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git/
 .docker-dev/
+tests/
 Makefile
 Dockerfile
 README.md

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM gliderlabs/alpine:3.2
+
+RUN apk-install curl bash
+RUN curl -sL https://github.com/progrium/basht/releases/download/v0.1.0/basht_0.1.0_Linux_x86_64.tgz \
+    | tar xvz -C /usr/local/bin
+RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.7.1 \
+      > /usr/local/bin/docker \
+    && chmod +x /usr/local/bin/docker
+CMD /bin/bash

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -6,4 +6,9 @@ RUN curl -sL https://github.com/progrium/basht/releases/download/v0.1.0/basht_0.
 RUN curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.7.1 \
       > /usr/local/bin/docker \
     && chmod +x /usr/local/bin/docker
+
+# Based on https://github.com/wharsojo/wharsojo-docker-compose/blob/d3791d37aaa0ac7809b946d6a0a93c68fc3dfa74/Dockerfile#L4-L8
+RUN apk-install py-pip py-yaml \
+    && pip install -U docker-compose==1.3.3 \
+    && rm -rf `find / -regex '.*\.py[co]'`
 CMD /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ test:
 	@docker history jenkins-server-tests 1>/dev/null
 	docker run -ti --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v /tmp:/tmp \
 		-v `pwd`:/workspace \
 		jenkins-server-tests \
 		basht /workspace/tests/*.bash
@@ -68,4 +69,4 @@ test:
 test.build:
 	docker build -t jenkins-server-tests -f Dockerfile.test .
 
-.PHONY: install clean build start stop rebuild dev dev.dind dev.clean
+.PHONY: install clean build start stop rebuild dev dev.dind dev.clean test test.build

--- a/Makefile
+++ b/Makefile
@@ -55,4 +55,17 @@ dev.clean:
 	docker rm -fv jenkins-server-dev || true
 	sudo rm -rf .docker-dev/*
 
+# TODO: Get this to run inside the DinD instance we have around
+test:
+	@docker history jenkins-server-tests 1>/dev/null
+	docker run -ti --rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/workspace \
+		jenkins-server-tests \
+		basht /workspace/tests/*.bash
+
+# TODO: Get this to build inside the DinD instance we have around
+test.build:
+	docker build -t jenkins-server-tests -f Dockerfile.test .
+
 .PHONY: install clean build start stop rebuild dev dev.dind dev.clean

--- a/jenkins/bin/dasherize
+++ b/jenkins/bin/dasherize
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+# TODO: Change the test environment to be based on ubuntu / debian so we can
+#       write tests for it (this works fine on ubuntu but not on Alpine Linux)
+
+echo "$@" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed 's/\(\s\|(\)\+/-/g' \
+  | sed 's/--\+/-/g'

--- a/jenkins/bin/run.on.docker
+++ b/jenkins/bin/run.on.docker
@@ -1,18 +1,50 @@
 #!/usr/bin/env bash
 set -eu
 
-usage () { printf "\nUsage:\n\t $0 <image_name> <command>\n\n"; }
+usage () {
+  printf "\nUsage: $0 [--help] [image-name] [docker-run-opts] -- [command]\n"
+  printf "\n  image-name\t\tname for the docker image that will be built"
+  printf "\n  docker-run-opts\toptional 'docker run' options (currently supports '-e' only)"
+  printf "\n\n"
+}
+
+# We need at least 2 arguments for the script to work
 [[ "$#" -gt 1 ]] || (usage; exit 1)
 
 running_dir=$(dirname ${BASH_SOURCE[0]})
 source "${running_dir}/common"
 printscript ${BASH_SOURCE[0]}
 
-IMAGE=$1
-shift
+IMAGE=
+DOCKER_RUN_ARGS=
+
+# This is here for backwards compatibility only, should be dropped
+# in favor of explicitly passing in `-t` when we have a chance
+if ! [[ "${1}" =~ ^- ]]; then
+  IMAGE="$1"
+  shift 1
+fi
+
+while true; do
+  case "$1" in
+    --help)              (usage; exit 1);;
+    -e|--env|--env-file) DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS $1 $2"; shift 2;;
+    --)                  shift 1; break;;
+    -*)                  (echo "Can't handle '$1' argument"; exit 1);;
+    # This is here for backwards compatibility only, should be dropped
+    # in favor of explicitly passing in `--`s once we have a chance
+    *)                   break;;
+  esac
+done
+
+# Did an image get set?
+[[ -n "$IMAGE" ]] || (usage; exit 1)
+# Do we have a command to run?
+[[ "$#" -gt 0 ]] || (usage; exit 1)
+
 COMMAND=$@
 
 WORKSPACE=/opt/workspace
 
 docker build -t $IMAGE .
-docker run --rm -v "$(pwd)":${WORKSPACE} -w ${WORKSPACE} ${IMAGE} bash -c "${COMMAND}"
+docker run --rm -v "$(pwd)":${WORKSPACE} -w ${WORKSPACE} ${DOCKER_RUN_ARGS} ${IMAGE} bash -c "${COMMAND}"

--- a/jenkins/bin/run.on.docker
+++ b/jenkins/bin/run.on.docker
@@ -4,7 +4,9 @@ set -eu
 usage () {
   printf "\nUsage: $0 [--help] [image-name] [docker-run-opts] -- [command]\n"
   printf "\n  image-name\t\tname for the docker image that will be built"
-  printf "\n  docker-run-opts\toptional 'docker run' options (currently supports '-e' only)"
+  printf "\n  docker-run-opts\toptional 'docker run' options"
+  printf "\n\t\t\t(supported flags: '-e', '--env', '--env-file')"
+  printf "\n  command\t\tcommand to run inside the docker environment"
   printf "\n\n"
 }
 

--- a/jenkins/bin/run.with.compose
+++ b/jenkins/bin/run.with.compose
@@ -2,8 +2,9 @@
 set -eu
 
 usage () {
-  printf "\nUsage:\t $0 [--help] [docker-compose-file]"
-  printf "\n\t\tdocker-compose-file     .yml file to use with docker-compose command. Default: docker-compose.yml"
+  printf "\nUsage:\t $0 [--help] [docker-compose-opts]\n"
+  printf "\n  docker-compose-opts\toptional 'docker-compose' options"
+  printf "\n\t\t\t(supported flags: '-p', '--project-name', '-e')"
   printf "\n\n"
 }
 [[ "${1:-}" == "--help" ]] && (usage; exit 1)
@@ -12,10 +13,28 @@ running_dir=$(dirname ${BASH_SOURCE[0]})
 source "${running_dir}/common"
 printscript ${BASH_SOURCE[0]}
 
-COMPOSE_YML=${1:-'docker-compose.yml'}
+DOCKER_COMPOSE_ARGS=
+DOCKER_COMPOSE_RUN_ARGS=
+
+# This is here for backwards compatibility only, should be dropped
+# in favor of explicitly passing in `-f` when we have a chance
+if ! [[ "${1:-}" =~ ^- ]]; then
+  DOCKER_COMPOSE_ARGS="-f ${1:-docker-compose.yml}"
+  shift 1 || true
+fi
+
+while true; do
+  [[ "$#" -gt 0 ]] || break
+  case "$1" in
+    -e)                DOCKER_COMPOSE_RUN_ARGS="$DOCKER_COMPOSE_RUN_ARGS $1 $2"; shift 2;;
+    -p|--project-name) DOCKER_COMPOSE_ARGS="$DOCKER_COMPOSE_ARGS $1 $2"; shift 2;;
+    -*)                (echo "Can't handle '$1' argument"; exit 1);;
+    *)                 (usage; exit 1);;
+  esac
+done
 
 compose () {
-  docker-compose -f ${COMPOSE_YML} ${@}
+  docker-compose ${DOCKER_COMPOSE_ARGS} ${@}
 }
 
 # Clean up before start
@@ -26,7 +45,7 @@ compose build
 
 # Allow errors to happen during a build
 set +e
-compose run --rm mainrunner
+compose run --rm $DOCKER_COMPOSE_RUN_ARGS mainrunner
 exitcode="$?"
 # Get ready to return the appropriate exit code
 set -e

--- a/tests/run.on.docker.bash
+++ b/tests/run.on.docker.bash
@@ -1,0 +1,9 @@
+T_additionUsingBC() {
+  result="$(echo 2+2 | bc)"
+  [[ "$result" -eq 4 ]]
+}
+
+T_additionUsingDC() {
+  result="$(echo 2 2+p | dc)"
+  [[ "$result" -eq 4 ]]
+}

--- a/tests/run.on.docker.bash
+++ b/tests/run.on.docker.bash
@@ -1,9 +1,78 @@
-T_additionUsingBC() {
-  result="$(echo 2+2 | bc)"
-  [[ "$result" -eq 4 ]]
+export TEST_IMAGE='jenkins-server-test-run-on-docker'
+export WORKSPACE='/tmp/test-workspace'
+
+prepare.environment() {
+  mkdir -p $WORKSPACE
+  cat > $WORKSPACE/Dockerfile
 }
 
-T_additionUsingDC() {
-  result="$(echo 2 2+p | dc)"
-  [[ "$result" -eq 4 ]]
+run.on.docker() {
+  cd $WORKSPACE
+  image=$1
+  shift 1
+  /workspace/jenkins/bin/run.on.docker $image $*
+  cd - &>/dev/null
+}
+
+T_buildsAndRunsTheImage() {
+  prepare.environment <<-DOCKERFILE
+FROM gliderlabs/alpine:3.2
+RUN apk-install bash
+RUN apk-install curl
+DOCKERFILE
+
+  set -e
+  output=$(run.on.docker $TEST_IMAGE echo 'curl path: $(which curl)')
+  set +e
+
+  if ! [[ "${output}" =~ 'curl path: /usr/bin/curl' ]]; then
+    $T_fail "Something went wrong!"
+  fi
+}
+
+T_mountsCurrentDirectoryAsTheWorkspaceRootInsideTheContainer() {
+  prepare.environment <<-DOCKERFILE
+FROM gliderlabs/alpine:3.2
+RUN apk-install bash
+RUN date > /tmp/created-on-build
+DOCKERFILE
+
+  set -e
+  output=$(run.on.docker $TEST_IMAGE 'cp /tmp/created-on-build /opt/workspace')
+  set +e
+
+  if [[ ! -f "$WORKSPACE/created-on-build" ]]; then
+    $T_fail "Workspace was not mounted inside the container"
+  fi
+}
+
+T_setsTheWorkspaceCorrectly() {
+  prepare.environment <<-DOCKERFILE
+FROM gliderlabs/alpine:3.2
+RUN apk-install bash
+DOCKERFILE
+
+  set -e
+  output=$(run.on.docker $TEST_IMAGE 'echo Current dir: $(pwd)')
+  set +e
+
+  if ! [[ "${output}" =~ 'Current dir: /opt/workspace' ]]; then
+    $T_fail "Working directory not set"
+  fi
+}
+
+T_allowsDockerRunArgsToBeProvided() {
+  $T_fail "TODO"
+}
+
+T_returnsWithSameExitCodeAsTheCommandRan() {
+  $T_fail "TODO"
+}
+
+T_removesTheContainerRegardlessOfTheExitCode() {
+  $T_fail "TODO"
+}
+
+T_failsIfImageCantBeBuilt() {
+  $T_fail "TODO"
 }

--- a/tests/run.with.compose.bash
+++ b/tests/run.with.compose.bash
@@ -1,0 +1,99 @@
+export WORKSPACE='/tmp/test-workspace'
+
+prepare.environment() {
+  rm -rf $WORKSPACE
+  mkdir -p $WORKSPACE
+  cat > $WORKSPACE/docker-compose.yml
+}
+
+run.with.compose() {
+  cd $WORKSPACE
+  /workspace/jenkins/bin/run.with.compose $* 2>&1
+  exitcode=$?
+  cd - &>/dev/null
+  return $exitcode
+}
+
+T_runsMainRunnner() {
+  prepare.environment <<DOCKER_COMPOSE_YML
+mainrunner:
+  image: gliderlabs/alpine:3.2
+  command: echo Hello world
+DOCKER_COMPOSE_YML
+
+  output=$(run.with.compose)
+  exitcode=$?
+
+  if [[ "$exitcode" = '1' ]]; then
+    $T_fail "Build did not fail"
+    return
+  fi
+
+  if ! [[ "$output" =~ 'Hello world' ]]; then
+    $T_fail "Something went wrong!"
+  fi
+}
+
+T_buildsImagesBeforeRunning() {
+  prepare.environment <<DOCKER_COMPOSE_YML
+mainrunner:
+  build: .
+DOCKER_COMPOSE_YML
+
+  cat <<DOCKERFILE > $WORKSPACE/Dockerfile
+FROM gliderlabs/alpine:3.2
+RUN apk-install curl
+CMD ["sh", "-c", "echo curl path: \$(which curl)"]
+DOCKERFILE
+
+  output=$(run.with.compose)
+  exitcode=$?
+
+  if [[ "$exitcode" = '1' ]]; then
+    $T_fail "Build did not fail"
+    return
+  fi
+
+  if ! [[ "$output" =~ 'curl path: /usr/bin/curl' ]]; then
+    $T_fail "Something went wrong!"
+  fi
+}
+
+T_returnsAnErrorIfTheMainRunnerCommandFails() {
+  prepare.environment <<DOCKER_COMPOSE_YML
+mainrunner:
+  image: gliderlabs/alpine:3.2
+  command: exit 31
+DOCKER_COMPOSE_YML
+
+  output=$(run.with.compose)
+  exitcode=$?
+
+  if [[ "$exitcode" = '0' ]]; then
+    $T_fail "Build did not fail"
+    return
+  fi
+}
+
+T_allowsEnvVarsToBeProvidedToTheUnderlyingDockerComposeRunCommand() {
+  prepare.environment <<-DOCKERFILE
+mainrunner:
+  image: gliderlabs/alpine:3.2
+  command: sh -c 'env | grep "_VAR" || true'
+DOCKERFILE
+
+  output=$(run.with.compose -e OTHER_VAR="foo" -e A_VAR="env-var")
+  exitcode=$?
+
+  if [[ "$exitcode" != '0' ]]; then
+    $T_fail "Build failed"
+    return
+  fi
+
+  if ! [[ "$output" =~ 'A_VAR=env-var' ]]; then
+    $T_fail "Env var not passed on to docker compose run"
+  fi
+  if ! [[ "$output" =~ 'OTHER_VAR=foo' ]]; then
+    $T_fail "Env var not passed on to docker compose run"
+  fi
+}


### PR DESCRIPTION
This gives us a nice safety net around the current functionality provided by the scripts we use on the CI and it also opens up for us to clean up some of our jobs over there too.

---

For example, one of our jobs have this around:

``` sh
run.on.docker image_name "\
  PUSHER_TOKEN=... \
  BUILD_NUMBER=${BUILD_NUMBER} \
  BUILD_VERSION=\"1.0.0-$(cat BUILD_NUMBER)\" \
  ENV_LABEL='staging' \
  make dist"
```

This has already given us some trouble because of bash interpolation and thanks to these changes we can make things less error prone:

``` sh
run.on.docker image_name \
  -e PUSHER_TOKEN='...' \
  -e BUILD_NUMBER=${BUILD_NUMBER} \
  -e BUILD_VERSION="1.0.0-$(cat BUILD_NUMBER)" \
  -e ENV_LABEL='staging' \
  -- make dist
```

Another option would be to place the env vars on a file and run:

``` sh
run.on.docker image_name --env-file /jenkins/envfile -- make dist
```

---

`run.with.compose` also have support for the `-e` flag and it will also support the `-p` flag which we can try combining with the `dasherize` script and keep docker-compose enabled jobs completely isolated from each other.

Without that in place, all of the docker-compose jobs will end up having `workspace` as the project name and one job can mess up with the other.

---

Once these changes and `dasherize` are known to work fine, we can then move on to automagically assigning build image / project names based on the jenkins job name.
